### PR TITLE
Bug/fix CSP header

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,6 +134,9 @@ def add_security_headers(response):
     response.headers[
         "Content-Security-Policy-Report-Only"
     ] = "default-src 'self'; script-src 'self' https://cdn.example.com; style-src 'self' https://cdn.example.com; img-src 'self' data: https://cdn.example.com; report-uri /csp-report-endpoint;"
+
+    # this one breaks the tiny chocobo icon
+    # response.headers["Cross-Origin-Embedder-Policy"] = "require-corp"
     return response
 
 

--- a/app.py
+++ b/app.py
@@ -115,6 +115,13 @@ def add_security_headers(response):
         [f"{key} {' '.join(value)}" for key, value in csp_policy.items()]
     )
     response.headers["Content-Security-Policy"] = csp_header_value
+    # Add other security headers
+    response.headers["X-Frame-Options"] = "same-origin"
+    response.headers["X-Content-Type-Options"] = "nosniff"
+    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains;"
+    response.headers["Referrer-Policy"] = "no-referrer-when-downgrade"
+    response.headers["Cross-Origin-Resource-Policy"] = "same-origin"
+    response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
     return response
 
 

--- a/app.py
+++ b/app.py
@@ -22,12 +22,16 @@ limiter = Limiter(get_remote_address, app=app, default_limits=["1 per second"])
 app.logger.setLevel(logging.INFO)
 app.logger.disabled = True
 logging.basicConfig(level=logging.INFO)
+
+
 class CustomLogHandler(logging.StreamHandler):
     def __init__(self):
         logging.StreamHandler.__init__(self)
 
     def format(self, record):
-        return f'{record.levelname}: {record.getMessage()}'
+        return f"{record.levelname}: {record.getMessage()}"
+
+
 custom_handler = CustomLogHandler()
 app.logger.addHandler(custom_handler)
 
@@ -42,6 +46,7 @@ def str_to_bool(bool_str):
 @app.route("/", methods=["GET", "POST"])
 def root():
     return render_template("index.html", len=len)
+
 
 #### WIP ####
 
@@ -63,6 +68,7 @@ def root():
 
 
 # should fix "Missing HTTP Header - Content-Security-Policy" once we get it to work with charts
+
 
 @app.after_request
 def add_security_headers(response):
@@ -118,10 +124,16 @@ def add_security_headers(response):
     # Add other security headers
     response.headers["X-Frame-Options"] = "same-origin"
     response.headers["X-Content-Type-Options"] = "nosniff"
-    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains;"
+    response.headers[
+        "Strict-Transport-Security"
+    ] = "max-age=31536000; includeSubDomains;"
     response.headers["Referrer-Policy"] = "no-referrer-when-downgrade"
     response.headers["Cross-Origin-Resource-Policy"] = "same-origin"
     response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
+    response.headers["X-XSS-Protection"] = "1; mode=block"
+    response.headers[
+        "Content-Security-Policy-Report-Only"
+    ] = "default-src 'self'; script-src 'self' https://cdn.example.com; style-src 'self' https://cdn.example.com; img-src 'self' data: https://cdn.example.com; report-uri /csp-report-endpoint;"
     return response
 
 

--- a/app.py
+++ b/app.py
@@ -59,38 +59,63 @@ def root():
 #     r.headers["Cross-Origin-Embedder-Policy"] = "require-corp"
 #     return r
 
+#### WIP ####
+
 
 # should fix "Missing HTTP Header - Content-Security-Policy" once we get it to work with charts
 
-# @app.after_request
-# def add_security_headers(response):
-#     # Add Content-Security-Policy header to the response
-#     csp_policy = {
-#         "default-src": ["'self'"],
-#         "script-src": [
-#             "'self'",
-#             "'unsafe-inline'",
-#             "https://code.jquery.com",
-#             "https://cdn.jsdelivr.net",
-#             "https://pagead2.googlesyndication.com",
-#         ],
-#         "style-src": ["'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net"],
-#         "img-src": [
-#             "'self'",
-#             "https://pagead2.googlesyndication.com",
-#             "https://saddlebagexchange.com",
-#         ],
-#         "font-src": ["'self'"],
-#         "connect-src": ["'self'"],
-#         "frame-src": ["'self'", "https://www.youtube.com"],
-#     }
-#     csp_header_value = "; ".join(
-#         [f"{key} {' '.join(value)}" for key, value in csp_policy.items()]
-#     )
-#     response.headers["Content-Security-Policy"] = csp_header_value
-#     return response
-
-#### WIP ####
+@app.after_request
+def add_security_headers(response):
+    # Add Content-Security-Policy header to the response
+    csp_policy = {
+        "default-src": ["'self'"],
+        "script-src": [
+            "'self'",
+            "'unsafe-inline'",
+            "https://code.jquery.com",
+            "https://cdn.jsdelivr.net",
+            "https://pagead2.googlesyndication.com",
+            "cdn.datatables.net",
+            "cdnjs.cloudflare.com",
+            "www.googletagmanager.com",
+            "partner.googleadservices.com",
+            "tpc.googlesyndication.com",
+        ],
+        "style-src": [
+            "'self'",
+            "'unsafe-inline'",
+            "https://cdn.jsdelivr.net",
+            "cdn.datatables.net",
+            "fonts.googleapis.com",
+        ],
+        "img-src": [
+            "'self'",
+            "data:",
+            "https://pagead2.googlesyndication.com",
+            "https://saddlebagexchange.com",
+        ],
+        "font-src": [
+            "'self'",
+            "fonts.gstatic.com",
+        ],
+        "connect-src": [
+            "'self'",
+            "pagead2.googlesyndication.com",
+            "www.google-analytics.com",
+        ],
+        "frame-src": [
+            "'self'",
+            "https://www.youtube.com",
+            "googleads.g.doubleclick.net",
+            "tpc.googlesyndication.com",
+            "www.google.com",
+        ],
+    }
+    csp_header_value = "; ".join(
+        [f"{key} {' '.join(value)}" for key, value in csp_policy.items()]
+    )
+    response.headers["Content-Security-Policy"] = csp_header_value
+    return response
 
 
 @app.route("/ffxiv", methods=["GET", "POST"])


### PR DESCRIPTION
## Why
Fix broken tables when adding a Content-Security-Policy header.


## Related Tickets

* Closes #6 


## Considerations

Additional context/info.
I fixed the broken tables by allowing the domains required by Data Tables through the CSP. I also unblocked a few other domains, like Google Tag Manager and Cloudflare. However, I'm not exactly sure which domains we should be allowing through. If needed, I can limit it to just the domains that Data Tables uses for now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced security by adding a Content-Security-Policy header to responses, resolving the "Missing HTTP Header - Content-Security-Policy" issue.
	- Updated directives to support additional sources for scripts, styles, images, fonts, connections, and frames, ensuring compatibility with charts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->